### PR TITLE
Replace deprecated `require('util')._extend` with `Object.assign`

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,14 +4,13 @@
  * All rights reserved.
  */
 
-var htmlencode = require('./encoder')
-  , extend = require('util')._extend;
+var htmlencode = require('./encoder');
 
 var Encoder = function (type) {
   if (type) this.EncodeType = type;
   return this;
 };
-extend(Encoder.prototype, htmlencode);
+Object.assign(Encoder.prototype, htmlencode);
 
 var it = new Encoder();
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "Dan MacTough <danmactough@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "mocha": "~1"
+    "mocha": "~10"
   },
   "readmeFilename": "README.md",
   "directories": {


### PR DESCRIPTION
Hello, this fixes a deprecation warning I get in https://github.com/KevinGimbel/eleventy-plugin-mermaid/issues/8


```sh
(node:349871) [DEP0060] DeprecationWarning: The `util._extend` API is deprecated. Please use Object.assign() instead.
    at Object.<anonymous> ($PROJECTPATH/node_modules/htmlencode/index.js:14:1)
    at Module._compile (node:internal/modules/cjs/loader:1546:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1691:10)
    at Module.load (node:internal/modules/cjs/loader:1317:32)
    at Module._load (node:internal/modules/cjs/loader:1127:12)
    at TracingChannel.traceSync (node:diagnostics_channel:315:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:217:24)
    at Module.require (node:internal/modules/cjs/loader:1339:12)
    at require (node:internal/modules/helpers:135:16)
    at Object.<anonymous> ($PROJECTPATH/node_modules/@kevingimbel/eleventy-plugin-mermaid/.eleventy.js:1:20)
```

`util._extend` seems to be deprecated. I also updated Mocha to run the tests, it works without any issues. 

Could you please merge & release a new version? :)